### PR TITLE
Unify path handling with PathBuf/OsString

### DIFF
--- a/src/directory_flattener.rs
+++ b/src/directory_flattener.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{ffi::OsString, io::ErrorKind, path::PathBuf};
 
 use clap::Parser;
 use walkdir::WalkDir;
@@ -9,30 +9,22 @@ use crate::utils;
 #[clap(author, version, about, long_about = None)]
 pub struct Args {
     /// Input directory that will be walked and searched for replaypacks
-    #[clap(
-        short,
-        long,
-        default_value = "F:\\Projects\\DirectoryFlattenerRS\\processing\\input"
-    )]
-    pub input_directory: String,
+    #[clap(short, long, default_value = "processing/input", parse(from_os_str))]
+    pub input_directory: PathBuf,
 
     /// Output directory where the files will be copied into a flat directory structure
-    #[clap(
-        short,
-        long,
-        default_value = "F:\\Projects\\DirectoryFlattenerRS\\processing\\output"
-    )]
-    pub output_directory: String,
+    #[clap(short, long, default_value = "processing/output", parse(from_os_str))]
+    pub output_directory: PathBuf,
 
     /// File extension which will be used to detect the files that ought to be copied to a new flat directory structure
-    #[clap(short, long, default_value = "SC2Replay")]
-    pub file_extension: String,
+    #[clap(short, long, default_value = "SC2Replay", parse(from_os_str))]
+    pub file_extension: OsString,
 }
 
 pub fn directory_flattener(
     main_input_dir: PathBuf,
     main_output_dir: PathBuf,
-    desired_extension: String,
+    desired_extension: OsString,
 ) {
     // Iterate over the depth 1 from input dir.
     // This accesses directories (replaypacks) that are within the input directory:
@@ -40,22 +32,28 @@ pub fn directory_flattener(
         .min_depth(1)
         .max_depth(1)
         .into_iter()
-        .filter_entry(|dir_entry| utils::is_dir(dir_entry))
+        .filter_entry(utils::is_dir)
         .map(|dir_entry| dir_entry.unwrap().path().to_owned());
 
     // Iterating over all of the replaypacks that were found in the input directory:
     for input_replaypack in intermediate_child_dirs {
         // Output dir is composed of the input dirs last component and the root of the output
-        let sub = &input_replaypack
-            .strip_prefix(main_input_dir.parent().unwrap())
-            .unwrap();
-        let output_dir = PathBuf::from_iter([PathBuf::from(&main_output_dir).as_path(), sub]);
+        let sub = &input_replaypack.strip_prefix(&main_input_dir).unwrap();
+        let output_dir = main_output_dir.join(sub);
+
+        // Remove the any old output directory in case it exists. Otherwise, every run would create
+        // duplicates as output file names are randomly generated.
+        match std::fs::remove_dir_all(&output_dir) {
+            Ok(_) => {}
+            Err(e) if e.kind() == ErrorKind::NotFound => {}
+            Err(e) => panic!("failed removing old output directory: {e}"),
+        }
 
         let files_to_copy =
             utils::get_filepaths(&input_replaypack, &output_dir, &desired_extension);
 
         utils::copy_files(&files_to_copy.input_to_output_vec);
 
-        utils::save_dir_mapping(output_dir, files_to_copy.directory_mapping);
+        utils::save_dir_mapping(&output_dir, &files_to_copy.directory_mapping);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,13 @@
 pub mod directory_flattener;
 pub mod utils;
 
-use std::path::PathBuf;
-
 use clap::Parser;
 
 fn main() {
     let args = directory_flattener::Args::parse();
 
-    let main_input_dir = PathBuf::from(&args.input_directory).canonicalize().unwrap();
-    let main_output_dir = PathBuf::from(args.output_directory).canonicalize().unwrap();
+    let main_input_dir = args.input_directory.canonicalize().unwrap();
+    let main_output_dir = args.output_directory.canonicalize().unwrap();
 
     let desired_extension = args.file_extension;
 


### PR DESCRIPTION
Cleaned up a lot of mixtures with `String`/`PathBuf`/`OsString` by not using `String` for any path handling. This allowed to remove a lot of unwraps (due to the UTF-8 requirement of `String` vs `PathBuf`/`OsString` not beeing guaranteed to be UTF-8).

Did some cleanups here and there as well and added a few lines that delete the output folder before copying files again, solving the problem of duplicate files due to multiple runs on the same input/output folders.

I wasn't 100% sure about the input folder iteration so please give it a run on your side to make sure it still works as expected.
